### PR TITLE
Trvalé zobrazení hlášky k námitkám

### DIFF
--- a/app/AuthenticatedModule/Components/templates/ObjectionForm.latte
+++ b/app/AuthenticatedModule/Components/templates/ObjectionForm.latte
@@ -10,14 +10,14 @@
 {varType Model\Objection\ObjectionsTime $objectionsTime}
 
 {if $isUserDelegate}
-    {if $objectionsTime->areObjectionsInProgress()}
-        <h2>Přidání námitky</h2>
-        <div class="alert alert-info">
-            Zde můžete podat oficiální námitku proti průběhu nebo výsledku Voleb a to nejpozději do 3 dnů po vyhlášení výsledků.
-            Námitkou se bude zabývat v souladu s vnitřním právem Rozhodčí a smírčí rada.
-            Podání námitky, prosíme, nejprve velmi pečlivě zvažte, neboť jde o velmi zásadní akt.
-        </div>
+    <h2>Přidání námitky</h2>
+    <div class="alert alert-info">
+        Zde můžete podat oficiální námitku proti průběhu nebo výsledku Voleb a to nejpozději do 3 dnů po vyhlášení výsledků.
+        Námitkou se bude zabývat v souladu s vnitřním právem Rozhodčí a smírčí rada.
+        Podání námitky, prosíme, nejprve velmi pečlivě zvažte, neboť jde o velmi zásadní akt.
+    </div>
 
+    {if $objectionsTime->areObjectionsInProgress()}
         {form form}
             <h4>{label text/}</h4>
             <div class="input-wrapper">
@@ -32,5 +32,9 @@
                     data-btn-ok-label="Podat námitku"
                     data-btn-cancel-label="Storno">Podat námitku</button>
          {/form}
+    {else}
+        <div class="alert alert-warning">
+            Námitky je možné přidávat pouze během voleb a do 3 dnů po vyhlášení výsledků.
+        </div>
     {/if}
 {/if}

--- a/app/AuthenticatedModule/Components/templates/ObjectionForm.latte
+++ b/app/AuthenticatedModule/Components/templates/ObjectionForm.latte
@@ -20,7 +20,7 @@
     {if $objectionsTime->areObjectionsInProgress()}
         {form form}
             <h4>{label text/}</h4>
-            <div class="input-wrapper">
+            <div class="input-wrapper mb-2">
                 {input text}
             </div>
 
@@ -34,7 +34,7 @@
          {/form}
     {else}
         <div class="alert alert-warning">
-            Námitky je možné přidávat pouze během voleb a do 3 dnů po vyhlášení výsledků.
+            Námitky je možné přidávat pouze od začátku voleb a až 3 dny po vyhlášení výsledků, tedy od {$objectionsTime->getBegin ()->format ('j. n. Y G:i')} do {$objectionsTime->getEnd ()->format ('j. n. Y G:i')}.
         </div>
     {/if}
 {/if}

--- a/app/AuthenticatedModule/Presenters/templates/Default/objections.latte
+++ b/app/AuthenticatedModule/Presenters/templates/Default/objections.latte
@@ -7,7 +7,7 @@
 {control objectionForm}
 
 {if $isUserRSRJ || $isUserAdmin}
-    <h2>Podané námitky</h2>
+    <h2 class="my-2">Podané námitky</h2>
     <div class="row">
         <div class="col-md-12">
             <table class="table table-bordered table-hover table-sm">

--- a/app/Model/Objection/Objection.php
+++ b/app/Model/Objection/Objection.php
@@ -23,7 +23,7 @@ class Objection extends Aggregate
     private int $id;
 
     /**
-     * @ORM\Column(type="string")
+     * @ORM\Column(type="text")
      */
     private string $text;
 

--- a/migrations/Version20200911084403.php
+++ b/migrations/Version20200911084403.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20200911084403 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        $this->addSql('ALTER TABLE objection CHANGE text text LONGTEXT NOT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->addSql('ALTER TABLE objection CHANGE text text VARCHAR(255) CHARACTER SET utf8 NOT NULL COLLATE `utf8_unicode_ci`');
+    }
+}


### PR DESCRIPTION
closes #103 

hláška popisující námitky se zobrazuje trvale, místo formuláře se mimo termín pro námitky zobrazí text: "Námitky je možné přidávat pouze během voleb a do 3 dnů po vyhlášení výsledků."

Nicméně ten text teď běžní delegáti neuvidí, protože se do systému nedá přihlásit mimo dobu voleb / námitek (uvidí ho když zůstanou přihlášení).

Tahle podmínka v AuthPresenteru by se tedy asi měla změnit tak, aby vyhazovala delegáty jen před začátkem hlasování a po skončení je tam pustila.
```if (! $votingTime->isVotingInProgress() && ! $objectionsTime->areObjectionsInProgress() && ! $this->userService->canBeAdmin())```
Tedy:
```if ($votingTime->isBeforeVoting() && ! $this->userService->canBeAdmin())```

Akorát si pak nejsem jistej, jestli nebude chtít upravit i něco na stránce s hlasovacím lístkem, jestli tam nebude potřeba přidat hlášky, že hlasování už skončilo apod.